### PR TITLE
Reformulate dml upsert

### DIFF
--- a/postpy/_version.py
+++ b/postpy/_version.py
@@ -1,3 +1,3 @@
-version_info = (0, 0, 8)
+version_info = (0, 0, 9)
 
 __version__ = '.'.join(map(str, version_info))

--- a/tests/test_dml.py
+++ b/tests/test_dml.py
@@ -194,7 +194,8 @@ class TestUpsertPrimary(PostgresStatementFixture, unittest.TestCase):
                                         self.columns,
                                         self.primary_keys)
 
-        expected = 'INSERT INTO foobar (foo, bar) VALUES (%s, %s)'
+        expected = ('INSERT INTO foobar AS current (foo, bar) VALUES (%s, %s)'
+                    ' ON CONFLICT (foo, bar) DO NOTHING')
         result = upserter.query
 
         self.assertSQLStatementEqual(expected, result)


### PR DESCRIPTION
* Have upsert expert query builder distinguish action on conflict.
* This allows for upserts when the table columns are all pkeys to be same function as when not.
* Specialized primary key upsert functions can be deprecated in future.